### PR TITLE
GH-692 upgrade dependencies, create push workflow

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,0 +1,62 @@
+name: Publish kafka-ui
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+      # Get the current date in YYYY-mm-dd format to be used as the image tag
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'zulu'
+          cache: 'maven'
+
+      - name: Build
+        id: build
+        run: |
+          ./mvnw -B -ntp versions:set -DnewVersion=${{ steps.date.outputs.date }}
+          ./mvnw -B -V -ntp clean package -Pprod -DskipTests
+          export VERSION=$(./mvnw -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      # The following two steps are needed to enable multi-platform Docker builds
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Docker Login
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ vars.CONTAINER_REGISTRY }}
+          username: ${{ secrets.JFROG_USER }}
+          password: ${{ secrets.JFROG_TOKEN }}
+      - name: Set Docker Metadata
+        uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ vars.CONTAINER_REGISTRY }}/${{ github.repository }}
+          tags: |
+            type=raw,value=${{ steps.date.outputs.date }}
+      - name: Docker Build
+        uses: docker/build-push-action@v5
+        with:
+          context: kafka-ui-api
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          build-args: |
+            JAR_FILE=kafka-ui-api-${{ steps.build.outputs.version }}.jar

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <antlr4-maven-plugin.version>4.12.0</antlr4-maven-plugin.version>
         <apache.commons.version>2.11.1</apache.commons.version>
         <assertj.version>3.19.0</assertj.version>
-        <avro.version>1.11.1</avro.version>
+        <avro.version>1.11.4</avro.version>
         <byte-buddy.version>1.12.19</byte-buddy.version>
         <confluent.version>7.4.0</confluent.version>
         <datasketches-java.version>3.1.0</datasketches-java.version>


### PR DESCRIPTION
Updating avro version to 1.11.4 to fix (CVE-2024-47561)[https://www.cve.org/CVERecord?id=CVE-2024-47561].
Add new push workflow to build/upload new artifact to jFrog.